### PR TITLE
restructure onboarding to subchapters

### DIFF
--- a/book/website/_toc.yml
+++ b/book/website/_toc.yml
@@ -305,10 +305,12 @@
   - title: Onboarding New Members
     file: collaboration/onboarding  
     sections:
-    - title: Virtual Onboarding
+    - title: Important Aspects of Onbarding
+      file: collaboration/onboarding/onboarding-aspects
+    - title: Planning and Process
+      file: collaboration/onboarding/onboarding-planning
+    - title: Considerations for in-person and virtual
       file: collaboration/onboarding/onboarding-virtual
-    - title: In-person Onboarding
-      file: collaboration/onboarding/onboarding-inperson
   - title: Leadership in Data Science
     file: collaboration/leadership
     sections:

--- a/book/website/collaboration/onboarding.md
+++ b/book/website/collaboration/onboarding.md
@@ -2,50 +2,11 @@
 
 # Onboarding New Members
 
-
-## Background and Motivation
 Onboarding is the process of welcoming new team or community members through a set of structured interactions and materials that supports their interaction with the project. 
+
 As any initiative grows or welcomes new cohorts of membership, a thoughtful onboarding process plays a critical role in maintaining a healthy, active, and inclusive community. 
 
-Good onboarding process has several benefits: 
-1. Helps team members feel part of the team and starts building connections within the team and wider community
-2. Empowers the team member to get up to speed and start contributing faster 
-3. Ensures that team members have access to the resources and information they need, reducing the work of community managers in the medium-long term 
-4. Supports sustainable engagement with a project, helping people become regular contributors 
-5. Clear communication of policies and ways to working at the beginning establishes the team or community norms and best practices, helping to avoid misunderstandings, and maintaining a positive culture 
-
-(cl-onboarding-components)=
-## Key components of onboarding 
-
-Onboarding processes and structures will vary depending on the needs of the project, the types of people who participate, and the frequency that new contributors join. 
-However, when thinking about designing onboarding, there are several areas to consider covering: 
-> [name=Malvika] Several of these points are covered in the doc that Becki, Aida and Isabel wrote, maybe merge this with their draft of subchapter?
-*	A clear document or a README page with links to relevant materials and meetings if your project is hosted on GitHub 
-* Strategic materials that clearly spell out the aims of the project/programme/initiative (such as project introduction slides, programme 1-pager) 
-> [name=Malvika Sharan] Not sure what strategic materials is? Are there different name for that?
-* Reference materials that explain where to find information, how to ask for help, and governance such as the code of conduct 
-* Training materials or sessions covering tools and systems used by the project 
-* Regular or one-off sessions dedicated to newer members where they can ask questions or be walked through the contributing process 
-* Deliberate connections between new and more experienced members about their roles or specific aspects of the project
+While these pages concern onboarding of members into collaborative data science projects, many of the principles are general and apply to _any_ group of people working towards a common goal.
 
 
-It may also be useful to connect onboarding process content to {ref}`Personas and Pathways to contribution<pd-persona>` for a project if these have been mapped, to help with introducing the different ways people might contribute. 
-Onboarding doesn’t have to provide an exhaustive list of every single way to participate, but it should give people the knowledge and tools they need to find out more about the areas that interest them. 
 
-
-## Planning onboarding
-> [name=Malvika Sharan] this should be moved to the subchapter that the group wrote, or even split that subchapter into two based on grouped topics that go well together
-
-At the end of onboarding, new team members should have a strong idea of: 
-* How the team interacts and its working patterns (such as meetings, communication channels, file storage, review processes) 
-* Where to find policies, procedures, codes of conduct, and other information about the project 
-* Which tools are used by the project and how to find out more about how to use them 
-* How and where to ask questions 
-* Opportunities to get involved more deeply in the project or community 
-
-
-You should plan out your onboarding process to take each of these things into account. 
-It’s also useful to make the onboarding process transparent, such as storing materials in a dedicated folder in the project repository, so that it’s easier to scale, have someone else lead the onboarding, or to identify missing sections through feedback from the community. 
-
-Onboarding in-person or virtually can raise different challenges and things to consider. 
-The Virtual Onboarding chapter covers online onboarding in more detail. 

--- a/book/website/collaboration/onboarding/onboarding-aspects.md
+++ b/book/website/collaboration/onboarding/onboarding-aspects.md
@@ -1,0 +1,17 @@
+(cl-onboarding-aspects)=
+# Important Aspects of Onboarding
+
+Onboarding processes and structures will vary depending on the needs of the project, the types of people who participate, and the frequency that new contributors join. 
+
+A good onboarding process achieves the following: 
+1. Helps team members feel a supported part of the team and start building connections within the team and wider community
+2. Empowers the team member to get up to speed and start contributing faster 
+3. Ensures that team members have access to the resources and information they need
+4. Clearly communicates policies and ways to working early on to establish the team or community norms and best practices, helping to avoid misunderstandings, and maintaining a positive culture 
+5. All the above points supports sustainable engagement with a project, helping people become regular contributors
+
+
+The next section outlines key processes to consider when planning your onboarding.
+
+
+

--- a/book/website/collaboration/onboarding/onboarding-inperson.md
+++ b/book/website/collaboration/onboarding/onboarding-inperson.md
@@ -1,2 +1,0 @@
-(cl-onboarding-inperson)=
-# In-person Onboarding

--- a/book/website/collaboration/onboarding/onboarding-planning.md
+++ b/book/website/collaboration/onboarding/onboarding-planning.md
@@ -1,0 +1,107 @@
+(cl-onboarding-planning)=
+# Planning and Processes
+
+When thinking about designing onboarding, there are several areas to consider. These are briefly described below. It may be useful to lay these out explicitly in an onboarding document, manual or folder of resources. This creates a set of shared expectations and acts as a reference for new members to find information about resources. Such a document also contain information about who to ask for help if they have a problem.
+
+## Suggested Considerations
+
+### Group Culture
+
+Every group or workplace has a different culture, and expectations aren't always clear when a new member joins.
+You can help them settle in by making the culture clear in written form.
+
+This can be especially important for people who experience discrimination - do they know that they can approach you and be listened to if they experience harassment or discrimination?
+
+Group culture sections can include:
+* What is expected as part of the team - turnaround times for feedback, support, communication.
+* Expectations for working hours and flexible working policies.
+* Equality, inclusion and diversity statement.
+* Open science and how you expect the group to practice this.
+* Team code of conduct.
+* A list of meetings/projects to shadow so that new members can get a feel for how team members interact.
+
+### Key Contacts
+
+It can be hard to ask for help, particularly when working remotely - you can't just lean over to the person at the next desk and ask! 
+
+Key contacts could include:
+* Group technicians/managers.
+* Key collaborators, and information on what areas of the project they are involved in.
+* IT - include detail - is there a form, or a specific person to email?
+
+### Communication Channels
+
+- Preferred method of communications, _for example email, video call, slack message_
+- Ensure any communication preferences are ..communicated.. from the beginning.
+It should be a priority that the new team member is sent all relevant information to join these communications channels and someone should check that they have been able to set them up.
+Offer help with this process and also training on any communications channel that the new team member has not used before so that they can communicate with the other team members quickly after joining.
+
+### Accessing Shared Documents
+
+- What method of sharing is preferred? _for example google docs, RMarkdown, shared documents over email, GitHub, OneDrive_
+- Ensure invitations are set up for calendar meetings and access is in place.
+- Where are useful project materials held? Such as:
+    - Materials that clearly spell out the aims of the project
+    - Reference materials such as group policies.
+
+### Expectations in Meetings
+
+- Individuals may not have adequate access to equipment or the internet.
+Discussions about whether any support is required for home setup (for example webcams, microphone, laptop) can allow for any needs to be addressed.
+- Meeting etiquette - learning expectations for different meetings can be overwhelming for a new starter.
+Clearly outlining expected attendance and contributions can help overcome this, _for example, are attendees required to read the papers prior to journal club? Are attendees asked to present their work regularly? Are you expecting videos to be on?_
+- Meeting times - consider the circumstances of your group when organising regular meetings - does everyone have the same opportunity to attend? _for example some groups try to arrange Athena SWAN meeting times, whereby meetings occur between 10-3, meaning that those with children are more able to attend this_.
+
+### Training
+
+On tools and systems used by the group - for example GitHub and communication channels such as Slack.
+
+* Use [Zenodo](https://zenodo.org/), or a similar open repository, to host training materials for easier sharing.
+* Use a YouTube channel to store induction & training material for people to watch in their own time.
+* Consider running training & induction sessions frequently as new people join.
+* Consider a Slack channel for new joiners - for questions and discussion.
+* Consider providing Office Hours to support new joiners using new tools - for example, GitHub.
+* Try to make your training sessions as interactive as possible with exercises and discussions.
+* Get feedback on your training and use this to adjust and improve your resources.
+
+### Resources
+
+* Link to the group website.
+* Link to group social media accounts - Twitter, Facebook, Instagram.
+* Links to other resources - institution wellbeing services.
+* Links to group policies.
+
+### Glossary
+
+Are there any weird acronyms in your field/group?
+Consider sharing them with new members - then they'll know exactly what obscure software you're referring to!
+
+### Pathways to contribution
+
+It may also be useful to connect onboarding process content to {ref}`Personas and Pathways to contribution<pd-persona>` for a project if these have been mapped, to help with introducing the different ways people might contribute. 
+
+Onboarding doesn’t have to provide an exhaustive list of every single way to participate, but it should give people the knowledge and tools they need to find out more about the areas that interest them. 
+
+
+## Planning Considerations
+
+At the end of onboarding, new team members should have a strong idea of: 
+* How the team interacts and its working patterns (such as meetings, communication channels, file storage, review processes) 
+* Where to find policies, procedures, codes of conduct, and other information about the project 
+* Which tools are used by the project and how to find out more about how to use them 
+* How and where to ask questions 
+* Opportunities to get involved more deeply in the project or community 
+
+You should plan out your onboarding process to take each of these things into account. 
+
+Additionally, an onboarding process also needs to instil confidence and not overwhelm the new team member. To help with this, one could:
+
+- Space out communication, with the onboarding process potentially starting a some time before the new member joining the team.
+- Give some indication of the relative importance of each topic so that the team member does not feel that they need to learn everything at once. 
+- Consider a dedicate period (e.g. a week) where there is no obligation to carry out any formal work.
+
+
+It’s also useful to make the onboarding process transparent, such as storing materials in a dedicated folder in the project repository, so that it’s easier to scale, have someone else lead the onboarding, or to identify missing sections through feedback from the community.
+
+
+Onboarding in-person or virtually can raise different challenges and things to consider.  The next section touches on the key differences.

--- a/book/website/collaboration/onboarding/onboarding-virtual.md
+++ b/book/website/collaboration/onboarding/onboarding-virtual.md
@@ -1,7 +1,6 @@
 (cl-onboarding-virtual)=
 # Virtual Onboarding
 
-## Summary
 
 Joining a new group virtually is a very different experience from joining in person, and it can be hard to know if someone is struggling or isolated.  
 
@@ -11,7 +10,7 @@ This should include an introduction to the team, an ongoing support mechanism fo
 
 ## Introducing the Team
 
-It can be intimidating to be the first to speak as a new member - consider asking your team to introduce themselves first in meetings.
+It can be intimidating to be the first to speak as a new member - consider asking your team to introduce themselves first in meetings. Initial introductions could be part of the role of a buddy (see below).
 
 Names and roles are also easy to forget, particularly if we aren't seeing people in the office every day.
 It can be helpful to store this information somewhere, for example, by sending around an introductory or onboarding email.
@@ -21,85 +20,19 @@ An onboarding event sharing important information like contact details, organigr
 
 ## Support
 
-You can provide one-on-one support - such as a buddy for informal peer support, or a mentor, for more formal support.
+You can provide one-on-one support - such as a buddy for informal peer support, or a mentor, for more formal support. You may provide more than one buddy to take the pressure off individual relationships and also so that a remote-starter immediately meets another person.
+
 This helps the new joiner understand group norms, and allows them to ask any sensitive questions they wouldn't like to raise in a group discussion.
-You should consider that the buddy or mentor should remain for a longer period than would be needed with in person onboarding.
+
+You should consider that the buddy or mentor should remain for a longer period than would be needed with in person onboarding. 
+
+To help keep an informal relationship you may want to ensure that the buddy is not the line manager or collaborating with the new-starter on their first piece of work.
 
 Co-working with a buddy or several team members is another informal way to build relationships with new team members and is an informal environment to address any questions that may have arisen in the first few days or weeks of employment.
 
-## Onboarding Document Guidelines
 
-Your project can have an onboarding document, manual or folder of resources.
-This creates a set of shared expectations and acts as a reference for new members to find information about resources. It should also contain information about who to ask for help if they have a problem.
 
-### Suggested Sections and Content
 
-#### Group Culture
-
-Every group or workplace has a different culture, and expectations aren't always clear when a new member joins.
-You can help them settle in by making the culture clear in written form.
-
-This can be especially important for people who experience discrimination - do they know that they can approach you and be listened to if they experience harassment or discrimination?
-
-Group culture sections can include:
-* What is expected as part of the team - turnaround times for feedback, support, communication.
-* Expectations for working hours and flexible working policies.
-* Equality, inclusion and diversity statement.
-* Open science and how you expect the group to practice this.
-* Team code of conduct.
-
-#### Key Contacts
-
-It can be hard to ask for help, particularly when working remotely - you can't just lean over to the person at the next desk and ask!
-
-Key contacts could include:
-* Group technicians/managers.
-* Key collaborators, and info on what areas of the project they are involved in.
-* IT - include detail - is there a form, or a specific person to email?
-
-#### Communication Channels
-
-- Preferred method of communications, _for example email, video call, slack message_
-- Ensure any communication preferences are ..communicated.. from the beginning.
-It should be a priority that the new team member is sent all relevant information to join these communications channels and someone should check that they have been able to set them up.
-Offer help with this process and also training on any communications channel that the new team member has not used before so that they can communicate with the other team members quickly after joining.
-
-#### Accessing Shared Documents
-
-- What method of sharing is preferred? _for example google docs, RMarkdown, shared documents over email, GitHub, OneDrive_
-- Ensure invitations are set up for calendar meetings and access is in place.
-
-#### Expectations in Meetings
-
-- Individuals may not have adequate access to equipment or the internet.
-Discussions about whether any support is required for home setup (for example webcams, microphone, laptop) can allow for any needs to be addressed.
-- Meeting etiquette - learning expectations for different meetings can be overwhelming for a new starter.
-Clearly outlining expected attendance and contributions can help overcome this, _for example, are attendees required to read the papers prior to journal club? Are attendees asked to present their work regularly? Are you expecting videos to be on?_
-- Meeting times - consider the circumstances of your group when organising regular meetings - does everyone have the same opportunity to attend? _for example some groups try to arrange Athena SWAN meeting times, whereby meetings occur between 10-3, meaning that those with children are more able to attend this_.
-
-#### Training
-
-On tools, the group uses often - for example GitHub and communication channels such as Slack.
-
-* Use [Zenodo](https://zenodo.org/), or a similar open repository, to host training materials for easier sharing.
-* Use a Youtube channel to store induction & training material for people to watch in their own time.
-* Consider running training & induction sessions every 2-3 months as new people join.
-* Consider a Slack channel for new joiners - for questions and discussion.
-* Consider providing Office Hours to support new joiners using new tools - for example, GitHub.
-* Try to make your training sessions as interactive as possible with exercises and discussions.
-* Get feedback on your training and use this to adjust and improve your resources.
-
-#### Resources
-
-* Link to the group website.
-* Link to group social media accounts - Twitter, Facebook, Instagram.
-* Links to other resources - institution wellbeing services.
-* Links to group policies.
-
-#### Glossary
-
-Are there any weird acronyms in your field/group?
-Consider sharing them with new members - then they'll know exactly what obscure software you're referring to!
 
 ## Further reading
 


### PR DESCRIPTION
### Summary

Follow-on from discussions at the collab cafe on 07/07/21.  [Notes](https://hackmd.io/FhjqHN1KRkGbxHRZz3KY5Q) 

Restructured the onboarding chapters into a landing page and the following:
- Important Aspects of onboarding
- Planning and process
- Virtual Onboarding (TODO: make this `Considerations for virtual and in-person onboarding`).

This involved attempting to merge Arielle's chapter draft (see Notes) with [this PR](https://github.com/alan-turing-institute/the-turing-way/pull/1806).

### What should a reviewer concentrate their feedback on?

- Consistent styles between the two merged docs
- TODO: We discussed making the `Virtual Onboarding` more of a section comparing the key differences (see bottom section of the discussion). I will do this if I get round to it (late next week) before anyone else. 


### Acknowledging contributors

- [x] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: 
I think @Iain-s is the only one? 
